### PR TITLE
Add space-before-paren option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 node_modules
+.vscode-test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 .vscode-test
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -192,6 +192,11 @@
             "less",
             "scss"
           ]
+        },
+        "prettier.spaceBeforeFunctionParen": {
+          "description": "Put a space before function parenthesis",
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -65,7 +65,8 @@ function format(
 			noSpaceEmptyFn: config.noSpaceEmptyFn,
 			parser: config.parser,
 			semi: config.semi,
-			filepath: fileName
+			filepath: fileName,
+			spaceBeforeFunctionParen: config.spaceBeforeFunctionParen
 		},
 		customOptions
 	);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,6 +21,7 @@ export interface PrettierConfig {
     noSpaceEmptyFn?: boolean;
     parser?: ParserOption;
     semi?: boolean;
+    spaceBeforeFunctionParen: boolean;
 }
 
 /**


### PR DESCRIPTION
I really like this extension because it works smoother than others. However it is missing a option `spaceBeforeFunctionParen`. So I would like to contribute :). 

Hope! it will helps 👍 