### PR TITLE
#7 change to only register languages that are active in prettier

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,22 +4,20 @@ import EditProvider from './PrettierEditProvider';
 
 import { setupOutputHandler, channelCommand, showChannel } from './output';
 import { setupStatusHandler } from './status';
+import { getExtensionConfig } from './config';
 
 export function activate(context: ExtensionContext) {
     const editProvider = new EditProvider();
+    const config = getExtensionConfig();
+    const languages = config.getActiveLanguages();
 
-    return languages.getLanguages().then((vsLanguages) => {
-        context.subscriptions.push(
-            commands.registerCommand(channelCommand, showChannel),
-            languages.registerDocumentFormattingEditProvider(
-                vsLanguages,
-                editProvider
-            )
-        );
+    context.subscriptions.push(
+        commands.registerCommand(channelCommand, showChannel),
+        languages.registerDocumentFormattingEditProvider(languages, editProvider)
+    );
 
-        setupStatusHandler();
-        setupOutputHandler();
-    });
+    setupStatusHandler();
+    setupOutputHandler();
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
Make now prettier only register active languages with VSCode document editing provider